### PR TITLE
Networking Layer

### DIFF
--- a/AstroWeather.xcodeproj/project.pbxproj
+++ b/AstroWeather.xcodeproj/project.pbxproj
@@ -18,6 +18,12 @@
 		2CED82A52B8F86B6002B5FE4 /* LocationWeatherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED82A42B8F86B6002B5FE4 /* LocationWeatherView.swift */; };
 		2CED82A82B8F86E5002B5FE4 /* LocationWeatherViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED82A72B8F86E5002B5FE4 /* LocationWeatherViewModel.swift */; };
 		2CED82AA2B8F8A70002B5FE4 /* ViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED82A92B8F8A70002B5FE4 /* ViewModelFactory.swift */; };
+		2CED82AF2B8FB2F0002B5FE4 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED82AE2B8FB2F0002B5FE4 /* API.swift */; };
+		2CED82B12B8FB405002B5FE4 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED82B02B8FB405002B5FE4 /* NetworkService.swift */; };
+		2CED82B32B8FB490002B5FE4 /* NetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED82B22B8FB490002B5FE4 /* NetworkRequest.swift */; };
+		2CED82B52B8FB52F002B5FE4 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED82B42B8FB52F002B5FE4 /* NetworkError.swift */; };
+		2CED82B82B8FB745002B5FE4 /* WeatherData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED82B72B8FB745002B5FE4 /* WeatherData.swift */; };
+		2CED82BB2B8FBCB6002B5FE4 /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED82BA2B8FBCB6002B5FE4 /* WeatherService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,6 +58,12 @@
 		2CED82A42B8F86B6002B5FE4 /* LocationWeatherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationWeatherView.swift; sourceTree = "<group>"; };
 		2CED82A72B8F86E5002B5FE4 /* LocationWeatherViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationWeatherViewModel.swift; sourceTree = "<group>"; };
 		2CED82A92B8F8A70002B5FE4 /* ViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelFactory.swift; sourceTree = "<group>"; };
+		2CED82AE2B8FB2F0002B5FE4 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
+		2CED82B02B8FB405002B5FE4 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
+		2CED82B22B8FB490002B5FE4 /* NetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequest.swift; sourceTree = "<group>"; };
+		2CED82B42B8FB52F002B5FE4 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		2CED82B72B8FB745002B5FE4 /* WeatherData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherData.swift; sourceTree = "<group>"; };
+		2CED82BA2B8FBCB6002B5FE4 /* WeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,9 +114,11 @@
 		2CED82752B8F7B7A002B5FE4 /* AstroWeather */ = {
 			isa = PBXGroup;
 			children = (
-				2CED82A62B8F86D1002B5FE4 /* ViewModel */,
-				2CED82A32B8F83CA002B5FE4 /* Views */,
+				2CED82B92B8FBCAB002B5FE4 /* Services */,
 				2CED82A02B8F825B002B5FE4 /* Model */,
+				2CED82A32B8F83CA002B5FE4 /* Views */,
+				2CED82A62B8F86D1002B5FE4 /* ViewModel */,
+				2CED82AD2B8F9E43002B5FE4 /* Networking */,
 				2CED82762B8F7B7A002B5FE4 /* AstroWeatherApp.swift */,
 				2CED827A2B8F7B7D002B5FE4 /* Assets.xcassets */,
 				2CED827C2B8F7B7D002B5FE4 /* Preview Content */,
@@ -141,6 +155,7 @@
 			isa = PBXGroup;
 			children = (
 				2CED82A12B8F8286002B5FE4 /* Location.swift */,
+				2CED82B72B8FB745002B5FE4 /* WeatherData.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -161,6 +176,33 @@
 				2CED82A92B8F8A70002B5FE4 /* ViewModelFactory.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		2CED82AD2B8F9E43002B5FE4 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				2CED82B62B8FB557002B5FE4 /* Error */,
+				2CED82AE2B8FB2F0002B5FE4 /* API.swift */,
+				2CED82B02B8FB405002B5FE4 /* NetworkService.swift */,
+				2CED82B22B8FB490002B5FE4 /* NetworkRequest.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		2CED82B62B8FB557002B5FE4 /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				2CED82B42B8FB52F002B5FE4 /* NetworkError.swift */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
+		2CED82B92B8FBCAB002B5FE4 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				2CED82BA2B8FBCB6002B5FE4 /* WeatherService.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -295,10 +337,16 @@
 			files = (
 				2CED82A82B8F86E5002B5FE4 /* LocationWeatherViewModel.swift in Sources */,
 				2CED82792B8F7B7A002B5FE4 /* TabContainerView.swift in Sources */,
+				2CED82B12B8FB405002B5FE4 /* NetworkService.swift in Sources */,
+				2CED82B82B8FB745002B5FE4 /* WeatherData.swift in Sources */,
+				2CED82BB2B8FBCB6002B5FE4 /* WeatherService.swift in Sources */,
 				2CED82A22B8F8286002B5FE4 /* Location.swift in Sources */,
 				2CED82AA2B8F8A70002B5FE4 /* ViewModelFactory.swift in Sources */,
 				2CED82772B8F7B7A002B5FE4 /* AstroWeatherApp.swift in Sources */,
 				2CED82A52B8F86B6002B5FE4 /* LocationWeatherView.swift in Sources */,
+				2CED82B32B8FB490002B5FE4 /* NetworkRequest.swift in Sources */,
+				2CED82AF2B8FB2F0002B5FE4 /* API.swift in Sources */,
+				2CED82B52B8FB52F002B5FE4 /* NetworkError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AstroWeather/Model/WeatherData.swift
+++ b/AstroWeather/Model/WeatherData.swift
@@ -1,0 +1,50 @@
+//
+//  WeatherData.swift
+//  AstroWeather
+//
+//  Created by Iñaki Yabar Bilbao on 28/02/2024.
+//
+
+import Foundation
+
+struct WeatherData: Decodable {
+    let weather: [Weather]
+    let main: Main
+    let visibility: Int
+    let wind: Wind
+    let clouds: Clouds
+    let dt: Int
+    let timezone: Int
+    let name: String
+    
+    struct Weather: Decodable {
+        let id: Int
+        let main: String
+        let description: String
+        let icon: String
+    }
+    
+    struct Main: Decodable {
+        let temp: Double
+        let feelsLike: Double
+        let tempMin: Double
+        let tempMax: Double
+        let pressure: Int
+        let humidity: Int
+    }
+    
+    struct Wind: Decodable {
+        let speed: Double
+        let deg: Int
+        let gust: Double?
+    }
+    
+    struct Clouds: Decodable {
+        let all: Int
+    }
+    
+    struct Sys: Decodable {
+        let sunrise: Int
+        let sunset: Int
+    }
+}

--- a/AstroWeather/Networking/API.swift
+++ b/AstroWeather/Networking/API.swift
@@ -1,0 +1,25 @@
+//
+//  API.swift
+//  AstroWeather
+//
+//  Created by Iñaki Yabar Bilbao on 28/02/2024.
+//
+
+import Foundation
+
+enum APIs {
+    enum OpenWeatherMap {
+        case weather(latitude: Double, longitude: Double)
+        
+        private var baseURL: String {
+            switch self {
+            case .weather(let latitude, let longitude):
+                return "https://api.openweathermap.org/data/2.5/weather?lat=\(latitude)&lon=\(longitude)&APPID=\("9f023bcc4b89fa9fee4cbac24257bb73")&lang=es&units=metric" // TODO: API KEY
+            }
+        }
+        
+        var url: URL? {
+            URL(string: baseURL)
+        }
+    }
+}

--- a/AstroWeather/Networking/Error/NetworkError.swift
+++ b/AstroWeather/Networking/Error/NetworkError.swift
@@ -1,0 +1,15 @@
+//
+//  NetworkError.swift
+//  AstroWeather
+//
+//  Created by Iñaki Yabar Bilbao on 28/02/2024.
+//
+
+import Foundation
+
+public enum NetworkError: Error {
+    case httpError(statusCode: Int)
+    case decodingError(Error)
+    case invalidUrlError
+    case notConnectedToInternet
+}

--- a/AstroWeather/Networking/NetworkRequest.swift
+++ b/AstroWeather/Networking/NetworkRequest.swift
@@ -1,0 +1,13 @@
+//
+//  NetworkRequest.swift
+//  AstroWeather
+//
+//  Created by Iñaki Yabar Bilbao on 28/02/2024.
+//
+
+import Foundation
+
+struct NetworkRequest<T: Decodable> {
+    let urlRequest: URLRequest
+    let responseType: T.Type
+}

--- a/AstroWeather/Networking/NetworkService.swift
+++ b/AstroWeather/Networking/NetworkService.swift
@@ -1,0 +1,38 @@
+//
+//  NetworkService.swift
+//  AstroWeather
+//
+//  Created by Iñaki Yabar Bilbao on 28/02/2024.
+//
+
+import Foundation
+
+protocol NetworkServiceProtocol {
+    func get<T>(request: NetworkRequest<T>) async throws -> T
+}
+
+final class NetworkService: NetworkServiceProtocol {
+    private let session: URLSession
+    private let decoder: JSONDecoder
+    
+    init(session: URLSession = .shared, decoder: JSONDecoder = JSONDecoder()) {
+        self.session = session
+        self.decoder = decoder
+    }
+    
+    func get<T>(request: NetworkRequest<T>) async throws -> T {
+        let (data, response) = try await session.data(for: request.urlRequest)
+        
+        guard let response = response as? HTTPURLResponse else {
+            throw NetworkError.invalidUrlError
+        }
+        
+        if !(200..<300 ~= response.statusCode) {
+            throw NetworkError.httpError(statusCode: response.statusCode)
+        }
+        
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        
+        return try decoder.decode(request.responseType, from: data)
+    }
+}

--- a/AstroWeather/Networking/NetworkService.swift
+++ b/AstroWeather/Networking/NetworkService.swift
@@ -33,6 +33,14 @@ final class NetworkService: NetworkServiceProtocol {
         
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         
-        return try decoder.decode(request.responseType, from: data)
+        do {
+            return try decoder.decode(request.responseType, from: data)
+        } catch {
+            guard let error = error as? DecodingError else {
+                throw error
+            }
+            
+            throw NetworkError.decodingError(error)
+        }
     }
 }

--- a/AstroWeather/Services/WeatherService.swift
+++ b/AstroWeather/Services/WeatherService.swift
@@ -1,0 +1,28 @@
+//
+//  WeatherService.swift
+//  AstroWeather
+//
+//  Created by Iñaki Yabar Bilbao on 28/02/2024.
+//
+
+import Foundation
+
+final class WeatherService {
+    let networkService: NetworkService
+    
+    internal init(networkService: NetworkService) {
+        self.networkService = networkService
+    }
+    
+    func getWeather(for location: Location) async throws -> WeatherData {
+        guard let url = APIs.OpenWeatherMap.weather(latitude: location.latitude, longitude: location.longitude).url else {
+            throw NetworkError.invalidUrlError
+        }
+        
+        let urlRequest = URLRequest(url: url)
+
+        let request = NetworkRequest(urlRequest: urlRequest, responseType: WeatherData.self)
+        
+        return try await networkService.get(request: request)
+    }
+}

--- a/AstroWeather/Services/WeatherService.swift
+++ b/AstroWeather/Services/WeatherService.swift
@@ -7,14 +7,18 @@
 
 import Foundation
 
-final class WeatherService {
-    let networkService: NetworkService
+protocol WeatherFetcher {
+    func fetchWeather(for: Location) async throws -> WeatherData
+}
+
+final class WeatherService: WeatherFetcher {
+    let networkService: NetworkServiceProtocol
     
     internal init(networkService: NetworkService) {
         self.networkService = networkService
     }
     
-    func getWeather(for location: Location) async throws -> WeatherData {
+    func fetchWeather(for location: Location) async throws -> WeatherData {
         guard let url = APIs.OpenWeatherMap.weather(latitude: location.latitude, longitude: location.longitude).url else {
             throw NetworkError.invalidUrlError
         }

--- a/AstroWeather/ViewModel/LocationWeatherViewModel.swift
+++ b/AstroWeather/ViewModel/LocationWeatherViewModel.swift
@@ -10,16 +10,19 @@ import Foundation
 @MainActor
 class LocationWeatherViewModel: ObservableObject {
     @Published var weather: WeatherData? = nil
-    private let weatherService: WeatherService = WeatherService(networkService: NetworkService())
     let location: Location
     
-    init(location: Location) {
+    private let weatherFetcher: WeatherFetcher
+    
+    
+    init(location: Location, weatherFetcher: WeatherFetcher) {
         self.location = location
+        self.weatherFetcher = weatherFetcher
     }
     
     func loadLocationWeather() async throws {
         do {
-            let data = try await weatherService.getWeather(for: location)
+            let data = try await weatherFetcher.fetchWeather(for: location)
             weather = data
         }
     }

--- a/AstroWeather/ViewModel/LocationWeatherViewModel.swift
+++ b/AstroWeather/ViewModel/LocationWeatherViewModel.swift
@@ -7,10 +7,20 @@
 
 import Foundation
 
+@MainActor
 class LocationWeatherViewModel: ObservableObject {
+    @Published var weather: WeatherData? = nil
+    private let weatherService: WeatherService = WeatherService(networkService: NetworkService())
     let location: Location
     
     init(location: Location) {
         self.location = location
+    }
+    
+    func loadLocationWeather() async throws {
+        do {
+            let data = try await weatherService.getWeather(for: location)
+            weather = data
+        }
     }
 }

--- a/AstroWeather/ViewModel/ViewModelFactory.swift
+++ b/AstroWeather/ViewModel/ViewModelFactory.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
+
 class ViewModelFactory: ObservableObject {
+    @MainActor
     func makeLocationWeatherViewModel(for location: Location) -> LocationWeatherViewModel {
         return LocationWeatherViewModel(location: location)
     }

--- a/AstroWeather/ViewModel/ViewModelFactory.swift
+++ b/AstroWeather/ViewModel/ViewModelFactory.swift
@@ -9,8 +9,10 @@ import Foundation
 
 
 class ViewModelFactory: ObservableObject {
+    let weatherFetcher: WeatherFetcher = WeatherService(networkService: NetworkService())
+    
     @MainActor
     func makeLocationWeatherViewModel(for location: Location) -> LocationWeatherViewModel {
-        return LocationWeatherViewModel(location: location)
+        return LocationWeatherViewModel(location: location, weatherFetcher: weatherFetcher)
     }
 }

--- a/AstroWeather/Views/LocationWeatherView.swift
+++ b/AstroWeather/Views/LocationWeatherView.swift
@@ -11,7 +11,24 @@ struct LocationWeatherView: View {
     @StateObject var viewModel: LocationWeatherViewModel
     
     var body: some View {
-        Text(viewModel.location.name)
+        ZStack {
+            if let weather = viewModel.weather {
+                VStack {
+                    Text("\(weather.main.temp)°")
+                        .font(.largeTitle)
+                        .bold()
+                    
+                    Text(viewModel.location.name)
+                }
+            } else {
+                Text(viewModel.location.name)
+            }
+        }
+        .onAppear {
+            Task {
+                try! await viewModel.loadLocationWeather()
+            }
+        }
     }
 }
 

--- a/AstroWeather/Views/LocationWeatherView.swift
+++ b/AstroWeather/Views/LocationWeatherView.swift
@@ -33,6 +33,6 @@ struct LocationWeatherView: View {
 }
 
 #Preview {
-    let viewModel = LocationWeatherViewModel(location: Location.list.first!)
+    let viewModel = LocationWeatherViewModel(location: Location.list.first!, weatherFetcher: WeatherService(networkService: NetworkService()))
     return LocationWeatherView(viewModel: viewModel)
 }


### PR DESCRIPTION
## Description
This PR adds a basic networking layer, allowing to create HTTP requests to openWeatherMap API. It includes:
- Loading weather information when a location appears on screen
- Weather decodable model
- WeatherService to abstract viewModel from networking logic
- Error handling with custom error messages (TODO: Show errors in view)